### PR TITLE
Remove console.log when creating license

### DIFF
--- a/lib/License.js
+++ b/lib/License.js
@@ -149,7 +149,6 @@ let generateHash = (info, prodCode, appVersion, osType) =>
 let generateSerial = (id) =>
 {
   let regKey = crypt.encryptString(id).toString()
-  console.log(chunkString(regKey, 5))
   return chunkString(regKey, 5)
 }
 


### PR DESCRIPTION
Seems like the console.log was there for debugging reasons. Not necessary for production?